### PR TITLE
chore(CI): Reduce factsheet data refresh to weekly

### DIFF
--- a/.github/workflows/generate-factsheets.yml
+++ b/.github/workflows/generate-factsheets.yml
@@ -14,7 +14,7 @@ on:
         default: false
 
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 6 * * 1'
 
   push:
     branches:


### PR DESCRIPTION
## Summary
- `generate-factsheets.yml` was refreshing data/PDFs daily (`0 6 * * *`); changed to weekly, Mondays at 06:00 UTC (`0 6 * * 1`)
- This matches the schedule already used by `generate-notebooks.yml`, so both automated refresh workflows now run on the same weekly cadence

## Test plan
- [x] Verified the cron syntax change is the only diff
- [ ] Confirm next scheduled run fires on the expected Monday 06:00 UTC slot


---
_Generated by [Claude Code](https://claude.ai/code/session_018LNPSUP2bCN6TWR6gComSF)_